### PR TITLE
[김슬비] Add : 회원가입 레이아웃 작성

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -33,7 +33,14 @@ function App() {
           />
 
           <Stack.Screen name="SignIn" component={SignIn} />
-          <Stack.Screen name="SignUp" component={SignUp} />
+          <Stack.Screen
+            name="회원가입"
+            component={SignUp}
+            options={{
+              headerTitleAlign: 'center',
+              headerStyle: {shadowColor: 'white'},
+            }}
+          />
           <Stack.Screen
             name="MainHome"
             component={MainHome}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,1 @@
+declare module '*.png';

--- a/src/screens/SignUp/index.tsx
+++ b/src/screens/SignUp/index.tsx
@@ -1,12 +1,126 @@
 import React from 'react';
-import {Text, View} from 'react-native';
+import {
+  StyleSheet,
+  Text,
+  View,
+  KeyboardAvoidingView,
+  ScrollView,
+  Pressable,
+} from 'react-native';
+import {TextInput} from 'react-native-gesture-handler';
+import {SafeAreaView} from 'react-native-safe-area-context';
 
-const SignUp = () => {
+const SignUp = ({navigation}) => {
   return (
-    <View>
-      <Text>SignUp</Text>
-    </View>
+    <KeyboardAvoidingView
+      style={styles.fullscreen}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+      <SafeAreaView style={styles.flex}>
+        <ScrollView contentContainerStyle={styles.scroll}>
+          <View style={styles.inputWrapper}>
+            <View style={styles.nameWrapper}>
+              <View style={styles.lastName}>
+                <Text style={styles.text}>성</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="성을 입력해주세요"></TextInput>
+              </View>
+              <View style={styles.firstName}>
+                <Text style={styles.text}>이름</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="이름을 입력해주세요"></TextInput>
+              </View>
+            </View>
+            <View>
+              <Text style={styles.text}>이메일</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="이메일을 입력해주세요"></TextInput>
+            </View>
+            <View>
+              <Text style={styles.text}>비밀번호</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="비밀번호를 입력해주세요"></TextInput>
+            </View>
+            <View>
+              <Text style={styles.text}>비밀번호 확인</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="비밀번호를 다시 입력해주세요"></TextInput>
+            </View>
+          </View>
+          <View style={styles.flex}>
+            <Pressable
+              style={styles.btn}
+              onPress={() => navigation.navigate('SignIn')}>
+              <Text style={styles.btnText}>가입완료</Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    </KeyboardAvoidingView>
   );
 };
+
+const styles = StyleSheet.create({
+  fullscreen: {
+    flex: 1,
+    width: '100%',
+    paddingTop: 40,
+    paddingRight: 27,
+    paddingBottom: 60,
+    paddingLeft: 33,
+    backgroundColor: 'white',
+  },
+
+  flex: {flex: 1},
+  scroll: {flexGrow: 1},
+  inputWrapper: {flex: 2},
+
+  nameWrapper: {
+    flexDirection: 'row',
+    width: '100%',
+  },
+
+  lastName: {
+    width: '50%',
+    paddingRight: 5,
+  },
+
+  firstName: {
+    width: '50%',
+    paddingLeft: 5,
+  },
+
+  input: {
+    height: 48,
+    padding: 10,
+    marginBottom: 27.5,
+    borderWidth: 1,
+    borderRadius: 5,
+    borderColor: '#C4C4C4',
+    fontSize: 12,
+  },
+
+  text: {
+    marginBottom: 7.5,
+    fontSize: 12,
+  },
+
+  btn: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 52,
+    borderRadius: 5,
+    backgroundColor: '#C4C4C4',
+  },
+
+  btnText: {
+    color: 'white',
+    fontSize: 18,
+  },
+});
 
 export default SignUp;

--- a/src/screens/SignUp/index.tsx
+++ b/src/screens/SignUp/index.tsx
@@ -1,13 +1,13 @@
-import React, {useState} from 'react';
+import React, {useState, useCallback} from 'react';
 import {
   StyleSheet,
   Text,
   View,
   KeyboardAvoidingView,
+  Platform,
   ScrollView,
   Pressable,
   Image,
-  TouchableWithoutFeedback,
 } from 'react-native';
 import {TextInput} from 'react-native-gesture-handler';
 import {SafeAreaView} from 'react-native-safe-area-context';
@@ -15,6 +15,12 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 const SignUp = ({navigation}) => {
   const [hiddenPw, setHiddenPw] = useState(true);
   const [hiddenPwCheck, setHiddenPwCheck] = useState(true);
+
+  const hiddenPwHandler = useCallback(isHidden => {
+    return isHidden
+      ? require('@assets/images/Icon_feather_eye_off.png')
+      : require('@assets/images/Icon_feather_eye_on.png');
+  }, []);
 
   return (
     <KeyboardAvoidingView
@@ -52,17 +58,14 @@ const SignUp = ({navigation}) => {
                 style={styles.input}
                 placeholder="비밀번호를 입력해주세요"
                 secureTextEntry={hiddenPw}
+                textContentType="oneTimeCode"
               />
-              <TouchableWithoutFeedback onPress={() => setHiddenPw(!hiddenPw)}>
+              <Pressable onPress={() => setHiddenPw(!hiddenPw)}>
                 <Image
                   style={styles.iconEye}
-                  source={
-                    hiddenPw
-                      ? require('@assets/images/Icon_feather_eye_off.png')
-                      : require('@assets/images/Icon_feather_eye_on.png')
-                  }
+                  source={hiddenPwHandler(hiddenPw)}
                 />
-              </TouchableWithoutFeedback>
+              </Pressable>
             </View>
             <View>
               <Text style={styles.text}>비밀번호 확인</Text>
@@ -70,18 +73,14 @@ const SignUp = ({navigation}) => {
                 style={styles.input}
                 placeholder="비밀번호를 다시 입력해주세요"
                 secureTextEntry={hiddenPwCheck}
+                textContentType="oneTimeCode"
               />
-              <TouchableWithoutFeedback
-                onPress={() => setHiddenPwCheck(!hiddenPwCheck)}>
+              <Pressable onPress={() => setHiddenPwCheck(!hiddenPwCheck)}>
                 <Image
                   style={styles.iconEye}
-                  source={
-                    hiddenPwCheck
-                      ? require('@assets/images/Icon_feather_eye_off.png')
-                      : require('@assets/images/Icon_feather_eye_on.png')
-                  }
+                  source={hiddenPwHandler(hiddenPwCheck)}
                 />
-              </TouchableWithoutFeedback>
+              </Pressable>
             </View>
           </View>
         </ScrollView>

--- a/src/screens/SignUp/index.tsx
+++ b/src/screens/SignUp/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
   StyleSheet,
   Text,
@@ -6,11 +6,16 @@ import {
   KeyboardAvoidingView,
   ScrollView,
   Pressable,
+  Image,
+  TouchableWithoutFeedback,
 } from 'react-native';
 import {TextInput} from 'react-native-gesture-handler';
 import {SafeAreaView} from 'react-native-safe-area-context';
 
 const SignUp = ({navigation}) => {
+  const [hiddenPw, setHiddenPw] = useState(true);
+  const [hiddenPwCheck, setHiddenPwCheck] = useState(true);
+
   return (
     <KeyboardAvoidingView
       style={styles.fullscreen}
@@ -23,42 +28,70 @@ const SignUp = ({navigation}) => {
                 <Text style={styles.text}>성</Text>
                 <TextInput
                   style={styles.input}
-                  placeholder="성을 입력해주세요"></TextInput>
+                  placeholder="성을 입력해주세요"
+                />
               </View>
               <View style={styles.firstName}>
                 <Text style={styles.text}>이름</Text>
                 <TextInput
                   style={styles.input}
-                  placeholder="이름을 입력해주세요"></TextInput>
+                  placeholder="이름을 입력해주세요"
+                />
               </View>
             </View>
             <View>
               <Text style={styles.text}>이메일</Text>
               <TextInput
                 style={styles.input}
-                placeholder="이메일을 입력해주세요"></TextInput>
+                placeholder="이메일을 입력해주세요"
+              />
             </View>
             <View>
               <Text style={styles.text}>비밀번호</Text>
               <TextInput
                 style={styles.input}
-                placeholder="비밀번호를 입력해주세요"></TextInput>
+                placeholder="비밀번호를 입력해주세요"
+                secureTextEntry={hiddenPw}
+              />
+              <TouchableWithoutFeedback onPress={() => setHiddenPw(!hiddenPw)}>
+                <Image
+                  style={styles.iconEye}
+                  source={
+                    hiddenPw
+                      ? require('@assets/images/Icon_feather_eye_off.png')
+                      : require('@assets/images/Icon_feather_eye_on.png')
+                  }
+                />
+              </TouchableWithoutFeedback>
             </View>
             <View>
               <Text style={styles.text}>비밀번호 확인</Text>
               <TextInput
                 style={styles.input}
-                placeholder="비밀번호를 다시 입력해주세요"></TextInput>
+                placeholder="비밀번호를 다시 입력해주세요"
+                secureTextEntry={hiddenPwCheck}
+              />
+              <TouchableWithoutFeedback
+                onPress={() => setHiddenPwCheck(!hiddenPwCheck)}>
+                <Image
+                  style={styles.iconEye}
+                  source={
+                    hiddenPwCheck
+                      ? require('@assets/images/Icon_feather_eye_off.png')
+                      : require('@assets/images/Icon_feather_eye_on.png')
+                  }
+                />
+              </TouchableWithoutFeedback>
             </View>
           </View>
-          <View style={styles.flex}>
-            <Pressable
-              style={styles.btn}
-              onPress={() => navigation.navigate('SignIn')}>
-              <Text style={styles.btnText}>가입완료</Text>
-            </Pressable>
-          </View>
         </ScrollView>
+        <View style={styles.flex}>
+          <Pressable
+            style={styles.btn}
+            onPress={() => navigation.navigate('SignIn')}>
+            <Text style={styles.btnText}>가입완료</Text>
+          </Pressable>
+        </View>
       </SafeAreaView>
     </KeyboardAvoidingView>
   );
@@ -120,6 +153,12 @@ const styles = StyleSheet.create({
   btnText: {
     color: 'white',
     fontSize: 18,
+  },
+
+  iconEye: {
+    position: 'absolute',
+    right: 10,
+    bottom: 43,
   },
 });
 

--- a/src/screens/SignUp/index.tsx
+++ b/src/screens/SignUp/index.tsx
@@ -12,9 +12,11 @@ import {
 
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {TextInput} from 'react-native-gesture-handler';
+import {commonStyle} from '~/src/styles/commonStyle';
+import {SignUpScreenProps} from '~/src/types/type';
 import {theme} from '~/src/styles/theme';
 
-const SignUp = ({navigation}) => {
+const SignUp = ({navigation}: SignUpScreenProps) => {
   const [hiddenPw, setHiddenPw] = useState(true);
   const [hiddenPwCheck, setHiddenPwCheck] = useState(true);
 
@@ -26,17 +28,17 @@ const SignUp = ({navigation}) => {
 
   return (
     <KeyboardAvoidingView
-      style={styles.fullscreen}
+      style={commonStyle.fullscreen}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
       <SafeAreaView style={styles.innerFlex}>
-        <ScrollView contentContainerStyle={styles.scroll}>
+        <ScrollView>
           <View style={styles.nameWrapper}>
             <View style={styles.lastName}>
-              <Text style={styles.text}>성</Text>
+              <Text style={styles.inputText}>성</Text>
               <TextInput style={styles.input} placeholder="성을 입력해주세요" />
             </View>
             <View style={styles.firstName}>
-              <Text style={styles.text}>이름</Text>
+              <Text style={styles.inputText}>이름</Text>
               <TextInput
                 style={styles.input}
                 placeholder="이름을 입력해주세요"
@@ -44,14 +46,14 @@ const SignUp = ({navigation}) => {
             </View>
           </View>
           <View>
-            <Text style={styles.text}>이메일</Text>
+            <Text style={styles.inputText}>이메일</Text>
             <TextInput
               style={styles.input}
               placeholder="이메일을 입력해주세요"
             />
           </View>
           <View>
-            <Text style={styles.text}>비밀번호</Text>
+            <Text style={styles.inputText}>비밀번호</Text>
             <TextInput
               style={styles.input}
               placeholder="비밀번호를 입력해주세요"
@@ -66,7 +68,7 @@ const SignUp = ({navigation}) => {
             </Pressable>
           </View>
           <View>
-            <Text style={styles.text}>비밀번호 확인</Text>
+            <Text style={styles.inputText}>비밀번호 확인</Text>
             <TextInput
               style={styles.input}
               placeholder="비밀번호를 다시 입력해주세요"
@@ -83,9 +85,9 @@ const SignUp = ({navigation}) => {
         </ScrollView>
         <View style={styles.innerFlex}>
           <Pressable
-            style={styles.btn}
+            style={commonStyle.btn}
             onPress={() => navigation.navigate('SignIn')}>
-            <Text style={styles.btnText}>가입완료</Text>
+            <Text style={commonStyle.btnText}>가입완료</Text>
           </Pressable>
         </View>
       </SafeAreaView>
@@ -94,18 +96,7 @@ const SignUp = ({navigation}) => {
 };
 
 const styles = StyleSheet.create({
-  fullscreen: {
-    flex: 1,
-    width: '100%',
-    paddingTop: 20,
-    paddingRight: 27,
-    paddingBottom: 60,
-    paddingLeft: 33,
-    backgroundColor: 'white',
-  },
-
   innerFlex: {flex: 1},
-  scroll: {flexGrow: 1},
 
   nameWrapper: {
     flexDirection: 'row',
@@ -129,25 +120,12 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 8,
     borderColor: theme.colors.userGray,
-    fontSize: 12,
+    fontSize: theme.fontSizes.fontSmall,
   },
 
-  text: {
+  inputText: {
     marginBottom: 7.5,
-    fontSize: 12,
-  },
-
-  btn: {
-    height: 52,
-    borderRadius: 8,
-    backgroundColor: theme.colors.userGray,
-  },
-
-  btnText: {
-    textAlign: 'center',
-    lineHeight: 52,
-    fontSize: 18,
-    color: 'white',
+    fontSize: theme.fontSizes.fontSmall,
   },
 
   iconEye: {

--- a/src/screens/SignUp/index.tsx
+++ b/src/screens/SignUp/index.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback} from 'react';
+import React, {useState} from 'react';
 import {
   StyleSheet,
   Text,
@@ -9,22 +9,21 @@ import {
   Pressable,
   Image,
 } from 'react-native';
-
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {TextInput} from 'react-native-gesture-handler';
 import {commonStyle} from '~/src/styles/commonStyle';
 import {SignUpScreenProps} from '~/src/types/type';
 import {theme} from '~/src/styles/theme';
+import eyeOff from 'assets/images/Icon_feather_eye_off.png';
+import eyeOn from 'assets/images/Icon_feather_eye_on.png';
 
 const SignUp = ({navigation}: SignUpScreenProps) => {
   const [hiddenPw, setHiddenPw] = useState(true);
   const [hiddenPwCheck, setHiddenPwCheck] = useState(true);
 
-  const hiddenPwHandler = useCallback(isHidden => {
-    return isHidden
-      ? require('@assets/images/Icon_feather_eye_off.png')
-      : require('@assets/images/Icon_feather_eye_on.png');
-  }, []);
+  const hiddenPwHandler = isHidden => {
+    return isHidden ? eyeOff : eyeOn;
+  };
 
   return (
     <KeyboardAvoidingView
@@ -33,11 +32,11 @@ const SignUp = ({navigation}: SignUpScreenProps) => {
       <SafeAreaView style={styles.innerFlex}>
         <ScrollView>
           <View style={styles.nameWrapper}>
-            <View style={styles.lastName}>
+            <View style={[styles.name, styles.lastName]}>
               <Text style={styles.inputText}>성</Text>
               <TextInput style={styles.input} placeholder="성을 입력해주세요" />
             </View>
-            <View style={styles.firstName}>
+            <View style={[styles.name, styles.firstName]}>
               <Text style={styles.inputText}>이름</Text>
               <TextInput
                 style={styles.input}
@@ -103,14 +102,16 @@ const styles = StyleSheet.create({
     width: '100%',
   },
 
-  lastName: {
+  name: {
     width: '50%',
-    paddingRight: 5,
   },
 
   firstName: {
-    width: '50%',
     paddingLeft: 5,
+  },
+
+  lastName: {
+    paddingRight: 5,
   },
 
   input: {

--- a/src/screens/SignUp/index.tsx
+++ b/src/screens/SignUp/index.tsx
@@ -9,8 +9,10 @@ import {
   Pressable,
   Image,
 } from 'react-native';
-import {TextInput} from 'react-native-gesture-handler';
+
 import {SafeAreaView} from 'react-native-safe-area-context';
+import {TextInput} from 'react-native-gesture-handler';
+import {theme} from '~/src/styles/theme';
 
 const SignUp = ({navigation}) => {
   const [hiddenPw, setHiddenPw] = useState(true);
@@ -26,65 +28,60 @@ const SignUp = ({navigation}) => {
     <KeyboardAvoidingView
       style={styles.fullscreen}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
-      <SafeAreaView style={styles.flex}>
+      <SafeAreaView style={styles.innerFlex}>
         <ScrollView contentContainerStyle={styles.scroll}>
-          <View style={styles.inputWrapper}>
-            <View style={styles.nameWrapper}>
-              <View style={styles.lastName}>
-                <Text style={styles.text}>성</Text>
-                <TextInput
-                  style={styles.input}
-                  placeholder="성을 입력해주세요"
-                />
-              </View>
-              <View style={styles.firstName}>
-                <Text style={styles.text}>이름</Text>
-                <TextInput
-                  style={styles.input}
-                  placeholder="이름을 입력해주세요"
-                />
-              </View>
+          <View style={styles.nameWrapper}>
+            <View style={styles.lastName}>
+              <Text style={styles.text}>성</Text>
+              <TextInput style={styles.input} placeholder="성을 입력해주세요" />
             </View>
-            <View>
-              <Text style={styles.text}>이메일</Text>
+            <View style={styles.firstName}>
+              <Text style={styles.text}>이름</Text>
               <TextInput
                 style={styles.input}
-                placeholder="이메일을 입력해주세요"
+                placeholder="이름을 입력해주세요"
               />
-            </View>
-            <View>
-              <Text style={styles.text}>비밀번호</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="비밀번호를 입력해주세요"
-                secureTextEntry={hiddenPw}
-                textContentType="oneTimeCode"
-              />
-              <Pressable onPress={() => setHiddenPw(!hiddenPw)}>
-                <Image
-                  style={styles.iconEye}
-                  source={hiddenPwHandler(hiddenPw)}
-                />
-              </Pressable>
-            </View>
-            <View>
-              <Text style={styles.text}>비밀번호 확인</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="비밀번호를 다시 입력해주세요"
-                secureTextEntry={hiddenPwCheck}
-                textContentType="oneTimeCode"
-              />
-              <Pressable onPress={() => setHiddenPwCheck(!hiddenPwCheck)}>
-                <Image
-                  style={styles.iconEye}
-                  source={hiddenPwHandler(hiddenPwCheck)}
-                />
-              </Pressable>
             </View>
           </View>
+          <View>
+            <Text style={styles.text}>이메일</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="이메일을 입력해주세요"
+            />
+          </View>
+          <View>
+            <Text style={styles.text}>비밀번호</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="비밀번호를 입력해주세요"
+              secureTextEntry={hiddenPw}
+              textContentType="oneTimeCode"
+            />
+            <Pressable onPress={() => setHiddenPw(!hiddenPw)}>
+              <Image
+                style={styles.iconEye}
+                source={hiddenPwHandler(hiddenPw)}
+              />
+            </Pressable>
+          </View>
+          <View>
+            <Text style={styles.text}>비밀번호 확인</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="비밀번호를 다시 입력해주세요"
+              secureTextEntry={hiddenPwCheck}
+              textContentType="oneTimeCode"
+            />
+            <Pressable onPress={() => setHiddenPwCheck(!hiddenPwCheck)}>
+              <Image
+                style={styles.iconEye}
+                source={hiddenPwHandler(hiddenPwCheck)}
+              />
+            </Pressable>
+          </View>
         </ScrollView>
-        <View style={styles.flex}>
+        <View style={styles.innerFlex}>
           <Pressable
             style={styles.btn}
             onPress={() => navigation.navigate('SignIn')}>
@@ -100,16 +97,15 @@ const styles = StyleSheet.create({
   fullscreen: {
     flex: 1,
     width: '100%',
-    paddingTop: 40,
+    paddingTop: 20,
     paddingRight: 27,
     paddingBottom: 60,
     paddingLeft: 33,
     backgroundColor: 'white',
   },
 
-  flex: {flex: 1},
+  innerFlex: {flex: 1},
   scroll: {flexGrow: 1},
-  inputWrapper: {flex: 2},
 
   nameWrapper: {
     flexDirection: 'row',
@@ -131,8 +127,8 @@ const styles = StyleSheet.create({
     padding: 10,
     marginBottom: 27.5,
     borderWidth: 1,
-    borderRadius: 5,
-    borderColor: '#C4C4C4',
+    borderRadius: 8,
+    borderColor: theme.colors.userGray,
     fontSize: 12,
   },
 
@@ -142,16 +138,16 @@ const styles = StyleSheet.create({
   },
 
   btn: {
-    alignItems: 'center',
-    justifyContent: 'center',
     height: 52,
-    borderRadius: 5,
-    backgroundColor: '#C4C4C4',
+    borderRadius: 8,
+    backgroundColor: theme.colors.userGray,
   },
 
   btnText: {
-    color: 'white',
+    textAlign: 'center',
+    lineHeight: 52,
     fontSize: 18,
+    color: 'white',
   },
 
   iconEye: {

--- a/src/styles/commonStyle.ts
+++ b/src/styles/commonStyle.ts
@@ -1,46 +1,41 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
-import { theme } from '~/src/styles/theme'
+import {StyleSheet} from 'react-native';
+import {theme} from '~/src/styles/theme';
 
 export const commonStyle = StyleSheet.create({
-    fullscreen: {
-        flex: 1,
-        width: '100%',
-        paddingTop: 20,
-        paddingRight: 27,
-        paddingBottom: 60,
-        paddingLeft: 33,
-        backgroundColor: 'white',
-    },
+  fullscreen: {
+    flex: 1,
+    width: '100%',
+    paddingTop: 20,
+    paddingRight: 27,
+    paddingBottom: 60,
+    paddingLeft: 33,
+    backgroundColor: 'white',
+  },
 
-    ativeBtn:{
-        height: 52,
-        backgroundColor: theme.colors.puzzleGreen,
-        borderRadius: 8,
-    },
+  ativeBtn: {
+    height: 52,
+    backgroundColor: theme.colors.puzzleGreen,
+    borderRadius: 8,
+  },
 
-    emptyBtn: {
-        backgroundColor:'#fff',
-        borderWidth: 1,
-        borderColor: theme.colors.puzzleGreen,
-    },
+  emptyBtn: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: theme.colors.puzzleGreen,
+  },
 
-    btn:{
-        height: 52,
-        backgroundColor: theme.colors.userGray,
-        borderRadius: 8,
-    },
+  btn: {
+    height: 52,
+    backgroundColor: theme.colors.userGray,
+    borderRadius: 8,
+  },
 
-    btnText:{
-        color:'#fff',
-        textAlign:'center',
-        lineHeight: 52,
-        fontSize: 18,
-        fontWeight: '400',
-    },
-
-})
-
-
-
-
+  btnText: {
+    color: '#fff',
+    textAlign: 'center',
+    lineHeight: 52,
+    fontSize: 18,
+    fontWeight: '400',
+  },
+});

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -61,10 +61,8 @@ const colors = {
   RstvtDetailGray: '#777777',
 };
 
-const theme = {
+export const theme = {
   flex,
   fontSizes,
   colors,
 };
-
-export default theme;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,12 +1,3 @@
-const flex = {
-  flexBox: (direction = 'row', align = 'center', justify = 'center') => `
-    display: flex;
-    flex-direction: ${direction};
-    align-items: ${align};
-    justify-content: ${justify};
-  `,
-};
-
 const fontSizes = {
   fontLarge: 22,
   fontMedium: 18,
@@ -62,7 +53,6 @@ const colors = {
 };
 
 export const theme = {
-  flex,
   fontSizes,
   colors,
 };


### PR DESCRIPTION
### :: 최근 작업 주제
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

### :: 구현 목표 
-  회원가입 레이아웃 구현
![스크린샷 2022-06-27 오후 6 48 37](https://user-images.githubusercontent.com/93895746/175913714-0c0db859-1cb1-4a0c-8675-5237e7bb8d35.png)

<br />

### :: 구현 사항
1. 회원가입 레이아웃 기본 구조 완성
1-1. `<KeyboardAvoidingView>` 추가 : 텍스트를 입력할 때 키보드가 화면을 가리지 않게 하기 위해 사용했습니다.
1-2. `<ScrollView>` 추가 : RN은 웹처럼 자동으로 스크롤이 생기지 않으므로 `<ScrollView>` 로 감싸줌으로써 스크롤이 생길 수 있도록 추가했습니다.

2. 비밀번호 가리기 기능 구현
2-1. input placeholder 설정
2-2. secureTextEntry props에 hiddenPw 상태값 부여, Pressable 컴포넌트의 onPress로 true, false를 설정합니다. 
Image의 source props에서 현재 hiddenPw의 값이 true or false 인지 구분하여 이미지 경로를 동적으로 부여합니다.

3. 가입완료 버튼 레이아웃 작성
3-1. 실제 어플리케이션을 참고하여 `<ScrollView>` 밖으로 두었습니다. 스크롤 시 버튼은 하단에 고정됩니다.
3-2. 버튼 스타일은 commonStyle 에서 import 하여 사용했습니다.
3-3. 버튼 타입은 공식문서를 참고하여 Pressable 로 사용했습니다.
3-4. 버튼을 누르면 navigation.navigate을 통해 SignIn 페이지로 이동됩니다.

### :: 기타 질문 및 특이 사항
위의 2-2에서 클릭시 눈 이미지를 변경하는 로직을 구현하면서 궁금한 점이 있습니다.
비밀번호와 비밀번호 확인 코드가 중복되어서, 상단에 현재 비밀번호 상태를 인자로 넘겨주고, 이미지경로를 다르게 처리하는 방식으로 작성했습니다. 
useMemo는 특정 결과값을 재사용할 때 사용하고, useCallback 은 특정 함수를 새로 만들지 않고 재사용 하고 싶을 때 사용하는 것으로 이해하고 있습니다. 여기서 useCallback 을 사용하여 성능 최적화에 도움이 되도록 구현하고 싶은데 deps로 `[hiddenPw, hiddenPwCheck]` 를 지정해야할지, 현재 로직이 맞는지 확신이 안서서 질문 드립니다!
