### PR TITLE
[김슬비] 닥터 리스트 스크린

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react';
+import React, {useContext, useState} from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {createStackNavigator} from '@react-navigation/stack';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
@@ -11,92 +11,102 @@ import DocList from 'screens/DocList';
 import AppointmentCalendar from 'screens/AppointmentCalendar';
 import AppointmentSubmit from 'screens/AppointmentSubmit';
 import AppointmentDetail from 'screens/AppointmentDetail';
-import {RootStackParamList} from 'types/type';
+import {DocListProp, RootStackParamList} from 'types/type';
 import arrowLeft from 'assets/images/icon_feather_arrow_left.png';
 import {AuthContext} from 'AuthContext';
+import {doctorInfoContext} from 'AppointmentContext';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
 function App() {
   const {userState} = useContext(AuthContext);
+  const [doctorInfo, setDoctorInfo] = useState<DocListProp>({
+    id: 0,
+    doctor_department: '',
+    doctor_hospital: '',
+    doctor_name: '',
+    doctor_profile_img: '',
+  });
 
   function BackBtn() {
     return <Image source={arrowLeft} style={{marginLeft: 21}} />;
   }
 
   return (
-    <SafeAreaProvider>
-      <NavigationContainer>
-        <Stack.Navigator initialRouteName="Entry">
-          {userState.loggedIn ? (
-            <>
-              <Stack.Screen
-                name="Main"
-                component={Main}
-                options={{headerShown: false}}
-              />
-              <Stack.Screen
-                name="DocList"
-                component={DocList}
-                options={{
-                  headerBackTitleVisible: false,
-                  headerStyle: {shadowColor: 'white'},
-                  headerBackImage: () => <BackBtn />,
-                }}
-              />
-              <Stack.Screen
-                name="AppointmentCalendar"
-                component={AppointmentCalendar}
-                options={{
-                  title: '테스트 선생님',
-                  headerBackTitleVisible: false,
-                  headerTitleAlign: 'center',
-                  headerStyle: {shadowColor: 'white'},
-                  headerBackImage: () => <BackBtn />,
-                }}
-              />
-              <Stack.Screen
-                name="AppointmentSubmit"
-                component={AppointmentSubmit}
-              />
-              <Stack.Screen
-                name="AppointmentDetail"
-                component={AppointmentDetail}
-              />
-            </>
-          ) : (
-            <>
-              <Stack.Screen
-                name="Entry"
-                component={Entry}
-                options={{headerShown: false}}
-              />
-              <Stack.Screen
-                name="SignIn"
-                component={SignIn}
-                options={{
-                  title: '',
-                  headerBackTitleVisible: false,
-                  headerStyle: {shadowColor: 'white'},
-                  headerBackImage: () => <BackBtn />,
-                }}
-              />
-              <Stack.Screen
-                name="SignUp"
-                component={SignUp}
-                options={{
-                  title: '회원가입',
-                  headerTitleAlign: 'center',
-                  headerBackTitleVisible: false,
-                  headerStyle: {shadowColor: 'white'},
-                  headerBackImage: () => <BackBtn />,
-                }}
-              />
-            </>
-          )}
-        </Stack.Navigator>
-      </NavigationContainer>
-    </SafeAreaProvider>
+    <doctorInfoContext.Provider value={{doctorInfo, setDoctorInfo}}>
+      <SafeAreaProvider>
+        <NavigationContainer>
+          <Stack.Navigator initialRouteName="Entry">
+            {userState.loggedIn ? (
+              <>
+                <Stack.Screen
+                  name="Main"
+                  component={Main}
+                  options={{headerShown: false}}
+                />
+                <Stack.Screen
+                  name="DocList"
+                  component={DocList}
+                  options={{
+                    headerBackTitleVisible: false,
+                    headerStyle: {shadowColor: 'white'},
+                    headerBackImage: () => <BackBtn />,
+                  }}
+                />
+                <Stack.Screen
+                  name="AppointmentCalendar"
+                  component={AppointmentCalendar}
+                  options={{
+                    title: '테스트 선생님',
+                    headerBackTitleVisible: false,
+                    headerTitleAlign: 'center',
+                    headerStyle: {shadowColor: 'white'},
+                    headerBackImage: () => <BackBtn />,
+                  }}
+                />
+                <Stack.Screen
+                  name="AppointmentSubmit"
+                  component={AppointmentSubmit}
+                />
+                <Stack.Screen
+                  name="AppointmentDetail"
+                  component={AppointmentDetail}
+                />
+              </>
+            ) : (
+              <>
+                <Stack.Screen
+                  name="Entry"
+                  component={Entry}
+                  options={{headerShown: false}}
+                />
+                <Stack.Screen
+                  name="SignIn"
+                  component={SignIn}
+                  options={{
+                    title: '',
+                    headerBackTitleVisible: false,
+                    headerStyle: {shadowColor: 'white'},
+                    headerBackImage: () => <BackBtn />,
+                  }}
+                />
+                <Stack.Screen
+                  name="SignUp"
+                  component={SignUp}
+                  options={{
+                    title: '회원가입',
+                    headerTitleAlign: 'center',
+                    headerBackTitleVisible: false,
+                    headerStyle: {shadowColor: 'white'},
+                    headerBackImage: () => <BackBtn />,
+                  }}
+                />
+              </>
+            )}
+          </Stack.Navigator>
+        </NavigationContainer>
+      </SafeAreaProvider>
+    </doctorInfoContext.Provider>
   );
 }
 

--- a/src/AppointmentContext.tsx
+++ b/src/AppointmentContext.tsx
@@ -1,0 +1,18 @@
+import {createContext} from 'react';
+import {DocListProp} from 'types/type';
+
+type doctorInfoProp = {
+  doctorInfo: DocListProp;
+  setDoctorInfo: React.Dispatch<DocListProp>;
+};
+
+export const doctorInfoContext = createContext<doctorInfoProp>({
+  doctorInfo: {
+    id: 0,
+    doctor_department: '',
+    doctor_hospital: '',
+    doctor_name: '',
+    doctor_profile_img: '',
+  },
+  setDoctorInfo: () => {},
+});

--- a/src/components/DoctorDataCard.tsx
+++ b/src/components/DoctorDataCard.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import {Text, View, StyleSheet, Image} from 'react-native';
 import {theme} from 'styles/theme';
+import {DocListProp} from 'types/type';
 
-const DoctorDataList = ({item}) => {
+const DoctorDataCard = ({item}: {item: DocListProp}) => {
   return (
     <View style={[styles.listContents, styles.flexStyle]}>
       <Image source={{uri: item.doctor_profile_img}} style={styles.doctorImg} />
@@ -47,4 +48,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default DoctorDataList;
+export default DoctorDataCard;

--- a/src/screens/DocList/index.tsx
+++ b/src/screens/DocList/index.tsx
@@ -11,7 +11,7 @@ const DocList = ({route, navigation}: DocListScreenProps) => {
   const {id, name} = route.params;
   const [doctorListData, setDoctorListData] = useState<DocListProp[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
-  const [nextListData, setNextListData] = useState(0);
+  const [nextData, setNextData] = useState(true);
   const {setDoctorInfo} = useContext(doctorInfoContext);
 
   useEffect(() => {
@@ -31,7 +31,10 @@ const DocList = ({route, navigation}: DocListScreenProps) => {
     );
     const res = await doctorData.json();
     const data = res.result;
-    setNextListData(data.length);
+
+    if (!data) {
+      setNextData(false);
+    }
     setDoctorListData([...doctorListData, ...data]);
   };
 
@@ -40,12 +43,10 @@ const DocList = ({route, navigation}: DocListScreenProps) => {
   }, [currentPage]);
 
   const loadMoreList = () => {
-    const DATA_SIZE_MAX = 6;
-    if (nextListData < DATA_SIZE_MAX) {
+    if (!nextData) {
       return;
-    } else {
-      setCurrentPage(prev => prev + 1);
     }
+    setCurrentPage(prev => prev + 1);
   };
 
   const goCalendar = (doctorInfo: DocListProp) => {

--- a/src/screens/DocList/index.tsx
+++ b/src/screens/DocList/index.tsx
@@ -1,16 +1,18 @@
-import React, {useEffect, useState} from 'react';
-import {View, SafeAreaView, StyleSheet, FlatList} from 'react-native';
+import React, {useContext, useEffect, useState} from 'react';
+import {SafeAreaView, StyleSheet, FlatList, Pressable} from 'react-native';
 import {theme} from 'styles/theme';
 import {DocListScreenProps, DocListProp} from 'types/type';
 import DoctorDataCard from 'components/DoctorDataCard';
 import {getToken} from 'AuthContext';
 import API from 'config';
+import {doctorInfoContext} from 'AppointmentContext';
 
 const DocList = ({route, navigation}: DocListScreenProps) => {
   const {id, name} = route.params;
   const [doctorListData, setDoctorListData] = useState<DocListProp[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [nextListData, setNextListData] = useState(0);
+  const {setDoctorInfo} = useContext(doctorInfoContext);
 
   useEffect(() => {
     navigation.setOptions({title: name});
@@ -46,14 +48,21 @@ const DocList = ({route, navigation}: DocListScreenProps) => {
     }
   };
 
+  const goCalendar = (doctorInfo: DocListProp) => {
+    setDoctorInfo(doctorInfo);
+    navigation.navigate('AppointmentCalendar');
+  };
+
   return (
     <SafeAreaView style={styles.mainListWrapper}>
       <FlatList
         data={doctorListData}
         renderItem={({item}: {item: DocListProp}) => (
-          <View style={styles.listContainer}>
+          <Pressable
+            style={styles.listContainer}
+            onPress={() => goCalendar(item)}>
             <DoctorDataCard item={item} />
-          </View>
+          </Pressable>
         )}
         keyExtractor={item => item.id.toString()}
         onEndReached={loadMoreList}

--- a/src/screens/DocList/index.tsx
+++ b/src/screens/DocList/index.tsx
@@ -1,19 +1,65 @@
-import React, {useEffect} from 'react';
-import {Text, View} from 'react-native';
-import {DocListScreenProps} from 'types/type';
+import React, {useEffect, useState} from 'react';
+import {View, SafeAreaView, StyleSheet, FlatList} from 'react-native';
+import {theme} from 'styles/theme';
+import {DocListScreenProps, DocListProp} from 'types/type';
+import DoctorDataCard from 'components/DoctorDataCard';
+import {getToken} from 'AuthContext';
+import API from 'config';
 
 const DocList = ({route, navigation}: DocListScreenProps) => {
-  const {id, name, thumbnails} = route.params;
+  const {id, name} = route.params;
+  const [doctorListData, setDoctorListData] = useState();
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     navigation.setOptions({title: name});
   }, []);
 
+  useEffect(() => {
+    const dataListFetch = async () => {
+      const token = await getToken();
+      const mainData = await fetch(
+        `${API.departmentList}/${id}?page=${currentPage}`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: token,
+          },
+        },
+      );
+      const res = await mainData.json();
+      const data = res.result;
+      setDoctorListData(data);
+    };
+    dataListFetch();
+  }, []);
+
   return (
-    <View>
-      <Text>{name}</Text>
-    </View>
+    <SafeAreaView style={styles.mainListWrapper}>
+      <FlatList
+        data={doctorListData}
+        renderItem={({item}: {item: DocListProp}) => (
+          <View style={styles.listContainer}>
+            <DoctorDataCard item={item} />
+          </View>
+        )}
+        keyExtractor={item => item.id.toString()}
+      />
+    </SafeAreaView>
   );
 };
+
+const styles = StyleSheet.create({
+  mainListWrapper: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+
+  listContainer: {
+    marginHorizontal: 18,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.mainBorderGray,
+  },
+});
 
 export default DocList;

--- a/src/screens/DocList/index.tsx
+++ b/src/screens/DocList/index.tsx
@@ -8,31 +8,43 @@ import API from 'config';
 
 const DocList = ({route, navigation}: DocListScreenProps) => {
   const {id, name} = route.params;
-  const [doctorListData, setDoctorListData] = useState();
+  const [doctorListData, setDoctorListData] = useState<DocListProp[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
+  const [nextListData, setNextListData] = useState(0);
 
   useEffect(() => {
     navigation.setOptions({title: name});
   }, []);
 
-  useEffect(() => {
-    const dataListFetch = async () => {
-      const token = await getToken();
-      const mainData = await fetch(
-        `${API.departmentList}/${id}?page=${currentPage}`,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: token,
-          },
+  const dataListFetch = async () => {
+    const token = await getToken();
+    const doctorData = await fetch(
+      `${API.departmentList}/${id}?page=${currentPage}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: token,
         },
-      );
-      const res = await mainData.json();
-      const data = res.result;
-      setDoctorListData(data);
-    };
+      },
+    );
+    const res = await doctorData.json();
+    const data = res.result;
+    setNextListData(data.length);
+    setDoctorListData([...doctorListData, ...data]);
+  };
+
+  useEffect(() => {
     dataListFetch();
-  }, []);
+  }, [currentPage]);
+
+  const loadMoreList = () => {
+    const DATA_SIZE_MAX = 6;
+    if (nextListData < DATA_SIZE_MAX) {
+      return;
+    } else {
+      setCurrentPage(prev => prev + 1);
+    }
+  };
 
   return (
     <SafeAreaView style={styles.mainListWrapper}>
@@ -44,6 +56,8 @@ const DocList = ({route, navigation}: DocListScreenProps) => {
           </View>
         )}
         keyExtractor={item => item.id.toString()}
+        onEndReached={loadMoreList}
+        onEndReachedThreshold={0.6}
       />
     </SafeAreaView>
   );

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -18,6 +18,14 @@ export type RootStackParamList = {
   Splash: undefined;
 };
 
+export interface DocListProp {
+  id: number;
+  doctor_name: string;
+  doctor_department: string;
+  doctor_hospital: string;
+  doctor_profile_img: string;
+}
+
 export type SignUpScreenProps = StackScreenProps<RootStackParamList, 'SignUp'>;
 
 export type SignInScreenProps = StackScreenProps<RootStackParamList, 'SignIn'>;


### PR DESCRIPTION
### :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

### :: 구현 목표 
- DocList 스크린 구현

<br />

![스크린샷 2022-07-11 오전 11 11 54](https://user-images.githubusercontent.com/93895746/178190257-5bcdde93-85ef-4838-8930-739bf420fe85.png)

### :: 구현 사항
1. DocList screen UI
- DoctorDataCard 컴포넌트 활용 UI 작성

2. API 통신 및 페이지네이션
- 선택된 진료과목의 id값과 현재 페이지넘버를 EndPoint에 할당한 주소로 API통신

3. AppointmentContext 관리
- doctorCard 클릭시 doctorInfo 상태 저장 및 네비게이션

### :: 기타 질문 및 특이 사항
페이지네이션 기능은 예약목록과 동일하게 구현했습니다.
doctorCard 데이터를 다른 screen에서도 참조할 수 있도록 Context로 작성했습니다.
