### PR TITLE
[박주영] 예약 확정 페이지 통신 및 기능 구현

### DIFF
--- a/src/AppointmentContext.tsx
+++ b/src/AppointmentContext.tsx
@@ -50,6 +50,7 @@ export const SelectContext = createContext<SelectProps>({
     selectedDay: 0,
     selectedDate: '',
     selectedTime: '',
+    selectedPostTime: '',
   },
 
   setSelectDate: () => {},

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,5 +7,6 @@ const API = {
   WorkingDayView: `${BASE_URL}/appointments/doctor`,
   WorkingTimeView: `${BASE_URL}/appointments/doctor`,
   appointments: `${BASE_URL}/appointments/list`,
+  appointmentPost: `${BASE_URL}/appointments/create`,
 };
 export default API;

--- a/src/screens/AppointmentCalendar/index.tsx
+++ b/src/screens/AppointmentCalendar/index.tsx
@@ -264,6 +264,7 @@ const AppointmentCalendar = ({
       selectedDay:
         selectedDayNumber > 25 ? WEEK[dayIndexDeduplication] : WEEK[dayIndex],
       selectTime: amPmDivision > 12 ? pmTime : amTime,
+      selectedPostTime: amPmDivision,
     });
 
     if (time === `${docAlreadyReservedTime}`) {

--- a/src/screens/AppointmentSubmit/AppointmentPost.tsx
+++ b/src/screens/AppointmentSubmit/AppointmentPost.tsx
@@ -91,7 +91,11 @@ const AppointmentPost = ({navigation}: AppointmentPostScreenProps) => {
           style={styles.submitBtn}>
           <Text style={styles.btnFont}>예약확정</Text>
         </Pressable>
-        <Pressable style={styles.correctionBtn}>
+        <Pressable
+          style={styles.correctionBtn}
+          onPress={() => {
+            navigation.navigate('AppointmentSubmit');
+          }}>
           <Text style={styles.btnFont}>예약수정</Text>
         </Pressable>
       </View>

--- a/src/screens/AppointmentSubmit/AppointmentPost.tsx
+++ b/src/screens/AppointmentSubmit/AppointmentPost.tsx
@@ -1,34 +1,66 @@
-import React from 'react';
+import React, {useContext, useState, useEffect} from 'react';
 import {Image, Pressable, StyleSheet, Text, View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {theme} from 'styles/theme';
 import completeIcon from 'assets/images/complete_icon.png';
+import {AppointmentPostScreenProps} from 'types/type';
+import {
+  DoctorInfoContext,
+  SelectContext,
+  SymtomInputValueContext,
+} from 'AppointmentContext';
 
-// TODO : 목데이터 통신 후 삭제 예정
-const APPOINTMENT_POST_DESC = [
-  {
-    id: 1,
-    title: '담당의사',
-    description: '홍정의(서울성모병원/코로나19상담센터)',
-  },
-  {
-    id: 2,
-    title: '신청일시',
-    description: '2020-12-18(금) 오후 1:13',
-  },
-  {
-    id: 3,
-    title: '예약일시',
-    description: '2020-12-21(월) 오후 3:00',
-  },
-  {
-    id: 4,
-    title: '예약내용',
-    description: '지난 금요일 발목을 접지른 이후 …',
-  },
-];
+import dayjs from 'dayjs';
+import 'dayjs/locale/ko';
 
-const AppointmentPost = () => {
+const AppointmentPost = ({navigation}: AppointmentPostScreenProps) => {
+  const {doctorInfo} = useContext(DoctorInfoContext);
+  const {selectDate} = useContext(SelectContext);
+  const {symtomInputValue} = useContext(SymtomInputValueContext);
+
+  const [currentTime, setCurrentTime] = useState('');
+  const [currentM, setCurrentM] = useState('');
+
+  const TODAY_DATE = dayjs();
+  dayjs.locale('ko');
+  const today = TODAY_DATE.format('YYYY-MM-DD(dd)');
+  const getCurrentMonth = TODAY_DATE.get('m');
+
+  useEffect(() => {
+    const getCurrentTime = TODAY_DATE.get('h');
+
+    if (getCurrentTime > 12) {
+      setCurrentTime(
+        `오후 ${Math.abs(12 - getCurrentTime)}:${getCurrentMonth}`,
+      );
+    } else {
+      setCurrentTime(`오전 ${getCurrentTime}:${getCurrentMonth}`);
+    }
+  }, []);
+
+  const submitData = [
+    {
+      id: 1,
+      title: '담당의사',
+      description: `${doctorInfo.doctor_name}(서울성모병원/코로나19상담센터)`,
+    },
+    {
+      id: 2,
+      title: '예약일시',
+      description: `${selectDate.year}-${selectDate.month}-${selectDate.selectedDate}(${selectDate.selectedDay}) ${selectDate.selectTime}`,
+    },
+    {
+      id: 3,
+      title: '신청일시',
+      description: `${today} ${currentTime}`,
+    },
+    {
+      id: 4,
+      title: '예약내용',
+      description: `${symtomInputValue}`,
+    },
+  ];
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.flexCenter}>
@@ -38,7 +70,7 @@ const AppointmentPost = () => {
 
       <View style={styles.borderDashed}></View>
 
-      {APPOINTMENT_POST_DESC.map(({id, title, description}) => (
+      {submitData.map(({id, title, description}) => (
         <View key={id} style={styles.flexRow}>
           <Text style={styles.title}>{title}</Text>
           <Text style={styles.descriptionStyle}>{description}</Text>
@@ -52,7 +84,11 @@ const AppointmentPost = () => {
         </Text>
       </View>
       <View style={styles.btnContainer}>
-        <Pressable style={styles.submitBtn}>
+        <Pressable
+          onPress={() => {
+            navigation.navigate('Main');
+          }}
+          style={styles.submitBtn}>
           <Text style={styles.btnFont}>예약확정</Text>
         </Pressable>
         <Pressable style={styles.correctionBtn}>

--- a/src/screens/AppointmentSubmit/index.tsx
+++ b/src/screens/AppointmentSubmit/index.tsx
@@ -22,8 +22,7 @@ const AppointmentSubmit = ({navigation}: AppointmentSubmitScreenProps) => {
   const {doctorInfo} = useContext(DoctorInfoContext);
 
   const onSubmit = () => {
-    // ToDo : 진료예약 확정 페이지 merge 후 수정
-    // navigation.navigate('진료예약 확정 페이지');
+    navigation.navigate('AppointmentPost');
   };
 
   return (


### PR DESCRIPTION
### :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

### :: 구현 목표 
1. 예약 확정 페이지 데이터 받아서 UI에 나타내기 
![저장된데이터UI로넘기기](https://user-images.githubusercontent.com/72453080/180163005-51841b74-f5cb-4ff1-b4b4-7a831b1a0f0d.gif)

2. 예약 확정 내용 POST 통신
![예약확정후POST로보내기](https://user-images.githubusercontent.com/72453080/180162990-d6ddffd6-a7e5-42da-b298-00f0f21e614f.gif)

3. 예약 수정 버튼 클릭 시 이전 페이지로 넘어가기
![예약수정시이전페이지로넘어가기](https://user-images.githubusercontent.com/72453080/180162947-07ba6bb7-3c13-403a-b26c-155b76b9e944.gif)

<br />

### :: 구현 사항
1. 예약 확정 페이지 데이터 받아서 UI에 나타내기 
- AppointmentSubmit에서 받아온 데이터를 배열 객체로 저장해서 mapping 후 확정페이지에 UI로 표시

2. 예약 확정 내용 POST 통신
- 예약 확정 버튼 클릭 시 POST 통신이 되면서 동시에 Main 페이지로 이동

3. 예약 수정 버튼 클릭 시 이전 페이지로 넘어가기
- 예약 수정 버튼 클릭시 이전 페이지인 AppointmentSubmit 페이지로 이동

### :: 기타 질문 및 특이 사항