### PR TITLE
[김슬비] 예약상세 기능 구현

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -27,7 +27,7 @@ const Stack = createStackNavigator<RootStackParamList>();
 function App() {
   const {userState} = useContext(AuthContext);
   const [doctorInfo, setDoctorInfo] = useState<DocListProp>({
-    id: 0,
+    doctor_id: 0,
     doctor_department: '',
     doctor_hospital: '',
     doctor_name: '',

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ const API = {
   WorkingDayView: `${BASE_URL}/appointments/doctor`,
   WorkingTimeView: `${BASE_URL}/appointments/doctor`,
   appointments: `${BASE_URL}/appointments/list`,
+  appointmentDetail: `${BASE_URL}/appointments/`,
   appointmentPost: `${BASE_URL}/appointments/create`,
 };
 export default API;

--- a/src/screens/AppointmentCalendar/index.tsx
+++ b/src/screens/AppointmentCalendar/index.tsx
@@ -52,7 +52,7 @@ const AppointmentCalendar = ({
   const {docWorkingDay, docWorkingTime, docAlreadyReservedTime} =
     docWorkingDatas;
 
-  const {id, doctor_name} = route.params;
+  const {doctor_id, doctor_name} = route.params;
 
   useEffect(() => {
     navigation.setOptions({title: `${doctor_name} 선생님`});
@@ -61,7 +61,7 @@ const AppointmentCalendar = ({
   const doctorWorkingDayFatchData = async () => {
     const token = await getToken();
     const getData = await fetch(
-      `${API.WorkingDayView}/${id}/workingday?year=${year}&month=${month}`,
+      `${API.WorkingDayView}/${doctor_id}/workingday?year=${year}&month=${month}`,
       {
         method: 'GET',
         headers: {
@@ -85,7 +85,7 @@ const AppointmentCalendar = ({
   const doctorWorkingTimeFatchData = async () => {
     const token = await getToken();
     const getData = await fetch(
-      `${API.WorkingTimeView}/${id}/workingtime?year=${year}&month=${month}&day=${userSelectedDate}`,
+      `${API.WorkingTimeView}/${doctor_id}/workingtime?year=${year}&month=${month}&day=${userSelectedDate}`,
       {
         method: 'GET',
         headers: {

--- a/src/screens/AppointmentDetail/index.tsx
+++ b/src/screens/AppointmentDetail/index.tsx
@@ -40,7 +40,7 @@ const AppointmentDetail = ({
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <ScrollView style={commonStyle.fullscreen}>
+      <View style={styles.fullscreen}>
         <DoctorDataCard item={doctorInfo} />
         <View style={styles.listLine} />
         <View style={styles.textContainer}>
@@ -54,7 +54,6 @@ const AppointmentDetail = ({
           <FlatList
             data={appointmentDetailData.Wound_img}
             keyExtractor={index => index.toString()}
-            style={styles.imgContainer}
             numColumns={2}
             renderItem={({item}) => (
               <Image
@@ -78,7 +77,7 @@ const AppointmentDetail = ({
             {appointmentDetailData.doctor_opinion}
           </Text>
         </View>
-      </ScrollView>
+      </View>
 
       <View style={styles.btnContainer}>
         <Pressable
@@ -98,6 +97,14 @@ const AppointmentDetail = ({
 
 const styles = StyleSheet.create({
   safeArea: {flex: 1, backgroundColor: 'white'},
+  fullscreen: {
+    flex: 1,
+    width: '100%',
+    paddingRight: 18,
+    paddingBottom: 60,
+    paddingLeft: 18,
+    backgroundColor: 'white',
+  },
 
   listLine: {
     marginBottom: 24,

--- a/src/screens/AppointmentDetail/index.tsx
+++ b/src/screens/AppointmentDetail/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useContext, useEffect} from 'react';
 import {
   Text,
   View,
@@ -6,43 +6,85 @@ import {
   SafeAreaView,
   ScrollView,
   Pressable,
+  Image,
 } from 'react-native';
 import DoctorDataCard from 'components/DoctorDataCard';
 import {commonStyle} from 'styles/commonStyle';
 import {theme} from 'styles/theme';
 import {AppointmentDetailScreenProps} from 'types/type';
+import API from 'config';
+import useFetch from 'components/useFetch';
+import Splash from 'screens/Splash';
+import {DoctorInfoContext} from 'AppointmentContext';
+import {FlatList} from 'react-native-gesture-handler';
 
-const AppointmentDetail = ({navigation}: AppointmentDetailScreenProps) => {
-  const goCalendar = () => {
-    navigation.navigate('AppointmentCalendar');
+const AppointmentDetail = ({
+  navigation,
+  route,
+}: AppointmentDetailScreenProps) => {
+  const {appointment_id} = route.params;
+  const {doctorInfo} = useContext(DoctorInfoContext);
+
+  const appointmentDetailUrl = `${API.appointmentDetail}${appointment_id}`;
+  const appointmentDetailData = useFetch(appointmentDetailUrl).result;
+
+  const isDataEmpty = appointmentDetailData === undefined;
+
+  const goCalendar = doctorInfo => {
+    navigation.navigate('AppointmentCalendar', doctorInfo);
   };
+
+  if (isDataEmpty) {
+    return <Splash />;
+  }
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <ScrollView style={commonStyle.fullscreen}>
-        <DoctorDataCard item={dataTest} />
+        <DoctorDataCard item={doctorInfo} />
         <View style={styles.listLine} />
         <View style={styles.textContainer}>
           <Text style={styles.title}>예약 날짜 및 시간</Text>
-          <Text style={styles.innerText}>2020-07-24(금) 오후 3:00</Text>
+          <Text style={styles.innerText}>
+            {appointmentDetailData.appointment_date}
+          </Text>
         </View>
         <View style={styles.textContainer}>
           <Text style={styles.title}>환부 사진</Text>
-          <Text style={styles.innerText}>사진/사진</Text>
+          <FlatList
+            data={appointmentDetailData.Wound_img}
+            keyExtractor={index => index.toString()}
+            style={styles.imgContainer}
+            numColumns={2}
+            renderItem={({item}) => (
+              <Image
+                style={styles.innerImg}
+                source={{
+                  uri: item,
+                }}
+              />
+            )}
+          />
         </View>
         <View style={styles.textContainer}>
           <Text style={styles.title}>환자 증상</Text>
-          <Text style={styles.innerText}>증상 입력 가져오기</Text>
+          <Text style={styles.innerText}>
+            {appointmentDetailData.patient_symptom}
+          </Text>
         </View>
         <View style={styles.textContainer}>
           <Text style={styles.title}>의사 소견</Text>
-          <Text style={styles.innerText}>의사 소견 가져오기</Text>
+          <Text style={styles.innerText}>
+            {appointmentDetailData.doctor_opinion}
+          </Text>
         </View>
       </ScrollView>
 
       <View style={styles.btnContainer}>
         <Pressable
-          onPress={goCalendar}
+          onPress={() => {
+            goCalendar(doctorInfo);
+          }}
           style={[commonStyle.ativeBtn, styles.leftBtn]}>
           <Text style={commonStyle.btnText}>다시 예약하기</Text>
         </Pressable>
@@ -93,14 +135,13 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     backgroundColor: theme.colors.RstvtInnerLightGray,
   },
+
+  innerImg: {
+    height: 106,
+    width: 106,
+    marginRight: 3,
+    backgroundColor: 'red',
+  },
 });
 
 export default AppointmentDetail;
-
-const dataTest = {
-  appointment_id: 1,
-  doctor_name: '홍정의',
-  doctor_hospital: '퍼즐AI병원',
-  doctor_department: 'COVID-19',
-  doctor_profile_img: 'https://reactjs.org/logo-og.png',
-};

--- a/src/screens/AppointmentSubmit/AppointmentPost.tsx
+++ b/src/screens/AppointmentSubmit/AppointmentPost.tsx
@@ -51,7 +51,7 @@ const AppointmentPost = ({navigation}: AppointmentPostScreenProps) => {
     formData.append('day', `${selectDate.selectedDate}`);
     formData.append('time', `${selectDate.selectedPostTime}`);
     formData.append('symptom', `${symtomInputValue}`);
-    formData.append('doctor_id', `${doctorInfo.id}`);
+    formData.append('doctor_id', `${doctorInfo.doctor_id}`);
     formData.append(
       'image',
       'image=@"/Users/hwangjaeseung/Desktop/스크린샷 2022-06-29 오후 5.13.15.png"',
@@ -65,7 +65,6 @@ const AppointmentPost = ({navigation}: AppointmentPostScreenProps) => {
       },
       body: formData,
     });
-    const data = res.json();
 
     if (res.status === 201) {
       Alert.alert('예약이 확정되었습니다.');

--- a/src/screens/DocList/index.tsx
+++ b/src/screens/DocList/index.tsx
@@ -31,7 +31,6 @@ const DocList = ({route, navigation}: DocListScreenProps) => {
     );
     const res = await doctorData.json();
     const data = res.result;
-
     if (!data) {
       setNextData(false);
       return;
@@ -66,7 +65,7 @@ const DocList = ({route, navigation}: DocListScreenProps) => {
             <DoctorDataCard item={item} />
           </Pressable>
         )}
-        keyExtractor={item => item.id.toString()}
+        keyExtractor={item => item.doctor_id.toString()}
         onEndReached={loadMoreList}
         onEndReachedThreshold={0.6}
       />

--- a/src/screens/Main/MainList.tsx
+++ b/src/screens/Main/MainList.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 import {
   Text,
   View,
@@ -6,19 +6,22 @@ import {
   StyleSheet,
   Image,
   FlatList,
+  Pressable,
 } from 'react-native';
 import {theme} from 'styles/theme';
 import DoctorDataCard from 'components/DoctorDataCard';
 import calendarImg from 'assets/images/calendar_icon_active.png';
 import API from 'config';
 import {getToken} from 'AuthContext';
-import {DocListProp} from 'types/type';
+import {DocListProp, MainListScreenProps} from 'types/type';
 import {appointmentsDataProp} from 'types/type';
+import {DoctorInfoContext} from 'AppointmentContext';
 
-const MainList = () => {
+const MainList = ({navigation}: MainListScreenProps) => {
   const [appointmentsData, setAppointmentsData] = useState<
     appointmentsDataProp[]
   >([]);
+  const {setDoctorInfo} = useContext(DoctorInfoContext);
 
   const [currentPage, setCurrentPage] = useState(1);
   const [nextData, setNextData] = useState(true);
@@ -50,9 +53,18 @@ const MainList = () => {
     setCurrentPage(prev => prev + 1);
   };
 
+  const goAppointmentDetail = item => {
+    setDoctorInfo(item);
+    navigation.navigate('AppointmentDetail', item);
+  };
+
   const renderItem = ({item}: {item: DocListProp}) => {
     return (
-      <View style={styles.listContainer}>
+      <Pressable
+        style={styles.listContainer}
+        onPress={() => {
+          goAppointmentDetail(item);
+        }}>
         <View style={[styles.listHeader, styles.flexStyle]}>
           <View style={[styles.dateBox, styles.flexStyle]}>
             <Image style={styles.calendarIcon} source={calendarImg} />
@@ -69,7 +81,7 @@ const MainList = () => {
           </Text>
         </View>
         <DoctorDataCard item={item} />
-      </View>
+      </Pressable>
     );
   };
 

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -21,7 +21,7 @@ export type RootStackParamList = {
 };
 
 export interface DocListProp {
-  id: number;
+  doctor_id: number;
   doctor_name: string;
   doctor_department: string;
   doctor_hospital: string;


### PR DESCRIPTION
### :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

### :: 구현 목표 
- 예약 상세보기 screen 기능 구현

<br />

![Jul-22-2022 00-20-28](https://user-images.githubusercontent.com/93895746/180251283-5ed726c8-828f-4778-b5a5-89349b4e589f.gif)

### :: 구현 사항
1. 예약 상세보기 데이터 통신
- useFetch를 통한 데이터 통신 및 UI 업데이트
- API 요청이 완료되기 전 Splash 화면이 보여짐

2. 예약 상세보기 screen 
- doctorCard 컴포넌트 재사용
- useContext 를 활용하여 UI 렌더링
- 다시 예약하기 클릭시 해당 의사 캘린더 페이지로 이동

### :: 기타 질문 및 특이 사항
환부 사진 데이터는 서버 단에서 지정해 둔 이미지를 가져와 사용했습니다.